### PR TITLE
Add a basic component generator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "presets": [
     "react",
     "es2015",
-    "stage-0"
+    "stage-0",
+    "stage-2"
   ],
   "plugins": ["add-module-exports", "array-includes"]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src/ -d dist",
     "lint": "eslint --ext .js --ext .jsx src",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "ava test/**/*-test.js --verbose --require ./test/helpers/setup-ava-tests.js"
   },
   "bin": {
     "rj": "./bin/rj"
@@ -35,6 +35,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "babel-register": "^6.7.2",
     "babel-runtime": "^6.6.1",
     "eslint": "^2.4.0",
@@ -43,11 +44,17 @@
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-react": "^4.2.3",
     "eslint-plugin-standard": "^1.3.2",
+    "jsdom": "^8.1.0",
     "webpack": "^1.12.14"
   },
   "dependencies": {
     "is-blank": "^1.1.0",
+    "is-present": "^1.0.0",
     "meow": "^3.7.0",
-    "ora": "^0.2.0"
+    "ora": "^0.2.0",
+    "uppercamelcase": "^1.1.0"
+  },
+  "ava": {
+    "babel": "inherit"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ npm i -g rj
 
   Examples
     $ rj new awesome-project
-    $ rj generate component profile-card
+    $ rj generate component profile-card username avatarUrl:string:required followers:number
     $ rj generate component profile-card --functional-component
     $ rj generate container users
     $ rj generate reducer users

--- a/src/generate/build-component.js
+++ b/src/generate/build-component.js
@@ -1,0 +1,55 @@
+import upperCamel from 'uppercamelcase'
+import isPresent from 'is-present'
+
+const buildComponent = (name, opts) => {
+  const componentName = upperCamel(name)
+
+  const props = opts.props || []
+  const propNames = props.map(prop => prop.split(':')[0])
+
+  const hasChildrenProp = props.some(prop => prop.indexOf('children') == 0)
+
+  if (!hasChildrenProp) {
+    propNames.push('children')
+    props.push('children:array')
+  }
+
+  const propsAsArgs = propNames.join(', ')
+
+  const propsAsHash = props.map(prop => {
+    const [name, type, required] = prop.split(':')
+    let str = `  ${name}: PropTypes.`
+    str += type || 'string'
+
+    if (isPresent(required)) {
+      str += '.required'
+    }
+
+    return `${str}`
+  }).join(',\n')
+
+  const propsAsLi = propNames.map(prop => `        <li>${prop}</li>`).join('\n')
+
+  return `import React, { PropTypes } from 'react'
+
+const ${componentName} = ({ ${propsAsArgs} }) => {
+  return (
+    <div>
+      <h1>Hello, I'm located in components/${name}</h1>
+      <h3>I accept the following properties
+      <ul>
+${propsAsLi}
+      </ul>
+    </div>
+  )
+}
+
+${componentName}.propTypes = {
+${propsAsHash}
+}
+
+export default ${componentName}
+`
+}
+
+export default buildComponent

--- a/test/generate/build-component-test.js
+++ b/test/generate/build-component-test.js
@@ -1,0 +1,47 @@
+import test from 'ava'
+import buildComponent from '../../src/generate/build-component'
+
+const expected = `import React, { PropTypes } from 'react'
+
+const Awesome = ({ foo, bar, children }) => {
+  return (
+    <div>
+      <h1>Hello, I'm located in components/awesome</h1>
+      <h3>I accept the following properties
+      <ul>
+        <li>foo</li>
+        <li>bar</li>
+        <li>children</li>
+      </ul>
+    </div>
+  )
+}
+
+Awesome.propTypes = {
+  foo: PropTypes.number.required,
+  bar: PropTypes.string,
+  children: PropTypes.array
+}
+
+export default Awesome
+`
+
+test('creates component', t => {
+  t.plan(1)
+
+  const output = buildComponent('awesome', {
+    props: ['foo:number:required', 'bar']
+  })
+
+  t.same(output, expected)
+})
+
+test('does not duplicate children prop', t => {
+  t.plan(1)
+
+  const output = buildComponent('awesome', {
+    props: ['foo:number:required', 'bar', 'children:array']
+  })
+
+  t.same(output, expected)
+})

--- a/test/helpers/setup-ava-tests.js
+++ b/test/helpers/setup-ava-tests.js
@@ -1,0 +1,11 @@
+/**
+ * This is used to set up the environment that's needed for most
+ * of the unit tests for the project which includes babel transpilation
+ * with babel-register, polyfilling, and initializing the DOM with jsdom
+ */
+require('babel-register')
+require('babel-polyfill')
+
+global.document = require('jsdom').jsdom('<body></body>')
+global.window = document.defaultView
+global.navigator = window.navigator


### PR DESCRIPTION
This integrates testing with ava and
adds a simple component generator module.

It uses one of the new template strings to
build up the string for the component. Though,
a lot of the variable preparation could, and
should, be broken into utils so that they
can be shared among generators.